### PR TITLE
ignore duplicate map entries

### DIFF
--- a/src/objects/dictionary.c
+++ b/src/objects/dictionary.c
@@ -4,12 +4,25 @@
 
 #include "dictionary.h"
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 /* VALUE FUNCTIONS */
 
+bool connection_in_values(const VALUE *val, const CONNECTION *connection) {
+  if (val == nullptr || connection == nullptr) {
+    return true;
+  }
+
+  for (int i = 0; i < val->size; ++i) {
+    const CONNECTION *tmp = &val->connections[i];
+    if (strcmp(tmp->destination.name, connection->destination.name) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 CONNECTION get_nearest(const VALUE value, const DICTIONARY* dict) {
   int smallest_distance = -1;

--- a/src/objects/dictionary.h
+++ b/src/objects/dictionary.h
@@ -49,6 +49,18 @@ typedef struct {
 // VALUE FUNCTIONS
 
 /**
+ * Checks if given connection is already in given value.
+ * This methode returns true, if given parameters where NULL, because
+ * calling methods will allocate memory if return value is false.
+ *
+ * @param val value containing connections.
+ * @param connection connection to check.
+ * @return true if given parameters where nullptr or connection is
+ * already in value, false otherwise.
+ */
+bool connection_in_values(const VALUE *val, const CONNECTION *connection);
+
+/**
  * Returns the connection with the smallest distance in the array of the passed value.
  * Passing a specific value implicitly means searching for the nearest connection to the city which has been the key to the passed value.
  */

--- a/src/parsing/parser.c
+++ b/src/parsing/parser.c
@@ -64,9 +64,14 @@ bool add_connection_to_dict(DICTIONARY *dictionary, const CITY *start_city,
     add_to_dictionary(dictionary, start_city, val);
   }
 
-  add(val,
-      (CONNECTION){
-          .city = *start_city, .destination = *dest_city, .distance = dist});
+  const CONNECTION connection = (CONNECTION){
+    .city = *start_city, .destination = *dest_city, .distance = dist};
+
+  if (connection_in_values(val, &connection)) {
+    return true;
+  }
+
+  add(val, connection);
   return true;
 }
 


### PR DESCRIPTION
Add a new method that checks if specified `VALUE` contains specified destination city. This method is now being called before `CONNECTION` is added to the dict.